### PR TITLE
Poco / 29주차 / 1.5문제

### DIFF
--- a/src/weekly29/poco/leetCode/1143_LongestCommonSubsequence.js
+++ b/src/weekly29/poco/leetCode/1143_LongestCommonSubsequence.js
@@ -1,0 +1,86 @@
+// https://leetcode.com/problems/longest-common-subsequence/
+
+/**
+ * @param {string} text1
+ * @param {string} text2
+ * @return {number}
+ */
+const longestCommonSubsequence = function (text1, text2) {
+  let dp = Array(text1.length + 1)
+    .fill(0)
+    .map(() => Array(text2.length + 1).fill(0));
+
+  for (let i = 1; i <= text1.length; i++) {
+    for (let j = 1; j <= text2.length; j++) {
+      if (text1[i - 1] === text2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  return dp[text1.length][text2.length];
+};
+
+// text1 : acd
+// text2: abcd
+
+// 매개변수
+// text1: 문자열
+// text2: 문자열
+
+// 출력
+// number: 가장 긴 공통 부분 문자열의 길이
+
+// 문제 설명 및 해결
+// 1. text1과 text2의 길이를 비교하여 더 긴 문자열의 길이를 dp의 행으로, 더 짧은 문자열의 길이를 dp의 열로 설정한다.
+// 2. dp의 행과 열의 길이는 각각 1을 더하여 설정한다.( dp[i][j] = dp[i - 1][j - 1] + 1에서 i - 1과 j - 1이 0이 되는 경우를 고려하기 위함이다.)
+// 3. dp의 행과 열을 0으로 초기화한다.
+// 4. text1의 문자열을 순회하면서 text2의 문자열을 순회한다.
+// 5. text1의 문자열과 text2의 문자열이 같으면 dp[i][j] = dp[i - 1][j - 1] + 1이다.
+// 6. text1의 문자열과 text2의 문자열이 다르면 dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1])이다.
+// 7. dp[text1.length][text2.length]를 반환한다.
+
+// =====================================================================================================================
+
+// 최초 풀이
+// 길이가 같은 두 문자열에서 일치한 문자를 하나 찾게되면, matchedIndex가 올라가게되면서,
+// 그 뒤에 나오는 문자들을 계산할 수 없다
+// 예를 들어, 아래 예시에서 "oxcp"의 "p"를 찾게되면,
+// "qr"을 찾을 수 없다
+// const longestCommonSubsequence = (text1, text2) => {
+//   const answer = [];
+
+//   let shortText, longText;
+
+//   if (text1.length <= text2.length) {
+//     shortText = text1;
+//     longText = text2;
+//   } else {
+//     shortText = text2;
+//     longText = text1;
+//   }
+
+//   let shortTextIndex = 0;
+//   let longTextIndex = 0;
+//   let matchedIndex = 0;
+
+//   while (shortTextIndex < shortText.length) {
+//     if (longTextIndex > longText.length) {
+//       shortTextIndex++;
+//       longTextIndex = matchedIndex;
+//     }
+//     if (shortText[shortTextIndex] === longText[longTextIndex]) {
+//       answer.push([longTextIndex, shortText[shortTextIndex]]);
+//       shortTextIndex++;
+//       longTextIndex++;
+//       matchedIndex = longTextIndex;
+//     } else {
+//       longTextIndex++;
+//     }
+//   }
+
+//   return answer.length;
+// };
+// console.log(longestCommonSubsequence('oxcpqrsvwf', 'shmtulqrypy'));

--- a/src/weekly29/poco/leetCode/695_MaxAreaOfIsland.js
+++ b/src/weekly29/poco/leetCode/695_MaxAreaOfIsland.js
@@ -1,0 +1,63 @@
+// https://leetcode.com/problems/max-area-of-island/
+
+/**
+ * @param {number[][]} grid
+ * @return {number}
+ */
+const maxAreaOfIsland = function (grid) {
+  const dfs = (row, col) => {
+    if (
+      row < 0 ||
+      row >= rowLength ||
+      col < 0 ||
+      col >= colLength ||
+      grid[row][col] === 0
+    ) {
+      return 0;
+    }
+
+    grid[row][col] = 0;
+
+    let area = 1;
+
+    area += dfs(row - 1, col);
+    area += dfs(row + 1, col);
+    area += dfs(row, col - 1);
+    area += dfs(row, col + 1);
+
+    return area;
+  };
+
+  let answer = 0;
+
+  const rowLength = grid.length; // 행의 길이
+  const colLength = grid[0].length; // 열의 길이
+
+  for (let row = 0; row < rowLength; row++) {
+    for (let col = 0; col < colLength; col++) {
+      if (grid[row][col] === 1) {
+        answer = Math.max(answer, dfs(row, col));
+      }
+    }
+  }
+
+  return answer;
+};
+
+// 매개변수
+// grid: 2차원 배열
+
+// 출력
+// number: 가장 큰 섬의 넓이
+
+// 문제 설명 및 해결
+// 2차원 배열 grid가 주어지고, 숫자 1은 땅, 숫자 0은 물을 의미한다.
+// 숫자 1이 연결된 부분은 하나의 섬이라고 할때, 주어진 2차원 배열에 존재하는 가장 큰 섬의 면적을 반환하는 문제.
+// 먼저 주어진 2차원 배열 grid의 행과 열의 길이를 구하고, 2중 for문을 통해 순회하면서 1을 찾는다.
+// 만약 1을 찾으면 dfs를 호출한다.
+// dfs 함수 내부에서는 만약 row 혹은 col이 0보다 작거나, row가 행의 길이보다 크거나, col이 열의 길이보다 크거나, grid[row][col]이 0이면 0을 반환한다.
+// row 혹은 col이 0보다 작거나, row가 행의 길이보다 크거나, col이 열의 길이보다 큰 경우는 주어진 2차원 배열을 넘어서는 탐색이기 때문이고
+// grid[row][col]이 0인 경우는 물이기 때문에 0을 반환한다.
+// 만약 위의 조건에 해당하지 않는 경우, 현재 row, col 위치를 기준으로 상하좌우의 row, col 값을 다시 dfs로 계산한다.
+// 처음 dfs의 return 값은 1이고 상하좌우 주위의 dfs 결과 값을 더해서 섬의 면적을 반환한다.
+// dfs의 최종 반환값은 기존 answer와 비교해서 큰 수를 answer에 저장한다.


### PR DESCRIPTION
### 문제 이름 : Max Area Of Island

### 매개변수
grid: 2차원 배열

### 출력
number: 가장 큰 섬의 넓이

### 문제 설명 및 해결
2차원 배열 grid가 주어지고, 숫자 1은 땅, 숫자 0은 물을 의미한다.
숫자 1이 연결된 부분은 하나의 섬이라고 할때, 주어진 2차원 배열에 존재하는 가장 큰 섬의 면적을 반환하는 문제.
먼저 주어진 2차원 배열 grid의 행과 열의 길이를 구하고, 2중 for문을 통해 순회하면서 1을 찾는다.
만약 1을 찾으면 dfs를 호출한다.
dfs 함수 내부에서는 만약 row 혹은 col이 0보다 작거나, row가 행의 길이보다 크거나, col이 열의 길이보다 크거나, grid[row][col]이 0이면 0을 반환한다.
row 혹은 col이 0보다 작거나, row가 행의 길이보다 크거나, col이 열의 길이보다 큰 경우는 주어진 2차원 배열을 넘어서는 탐색이기 때문이고
grid[row][col]이 0인 경우는 물이기 때문에 0을 반환한다.
만약 위의 조건에 해당하지 않는 경우, 현재 row, col 위치를 기준으로 상하좌우의 row, col 값을 다시 dfs로 계산한다.
처음 dfs의 return 값은 1이고 상하좌우 주위의 dfs 결과 값을 더해서 섬의 면적을 반환한다.
dfs의 최종 반환값은 기존 answer와 비교해서 큰 수를 answer에 저장한다.

--- 
### 문제 이름 : Longest Common Subsequence

### 매개변수
text1: 문자열
text2: 문자열

### 출력
number: 가장 긴 공통 부분 문자열의 길이

### 문제 설명 및 해결
1. text1과 text2의 길이를 비교하여 더 긴 문자열의 길이를 dp의 행으로, 더 짧은 문자열의 길이를 dp의 열로 설정한다.
2. dp의 행과 열의 길이는 각각 1을 더하여 설정한다.( dp[i][j] = dp[i - 1][j - 1] + 1에서 i - 1과 j - 1이 0이 되는 경우를 고려하기 위함이다.)
3. dp의 행과 열을 0으로 초기화한다.
4. text1의 문자열을 순회하면서 text2의 문자열을 순회한다.
5. text1의 문자열과 text2의 문자열이 같으면 dp[i][j] = dp[i - 1][j - 1] + 1이다.
6. text1의 문자열과 text2의 문자열이 다르면 dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1])이다.
7. dp[text1.length][text2.length]를 반환한다.
