### PR TITLE
Den / 31주차 / 2문제

### DIFF
--- a/src/weekly31/den/leetcode/215_kthLargestElementInAnArray.ts.ts
+++ b/src/weekly31/den/leetcode/215_kthLargestElementInAnArray.ts.ts
@@ -1,0 +1,77 @@
+/**
+ * 문제출처: https://leetcode.com/problems/kth-largest-element-in-an-array/
+ * 시작시간: 14:40
+ * 종료시간: 15:00
+ * 결과: test case 통과 실패(37/40)
+ */
+
+// function findKthLargest(nums: number[], k: number): number {
+//   for (let i = 0; i < nums.length; i++) {
+//     for (let j = i + 1; j < nums.length; j++) {
+//       if (nums[i] < nums[j]) {
+//         const temp = nums[i];
+//         nums[i] = nums[j];
+//         nums[j] = temp;
+//       }
+//     }
+//   }
+//   return nums[k - 1];
+// }
+
+// console.log(findKthLargest([3, 2, 1, 5, 6, 4], 2)); // 5
+// console.log(findKthLargest([3, 2, 3, 1, 2, 4, 5, 5, 6], 4)); // 4
+
+/**
+ * 두 번째 풀이: 성공
+ */
+
+function findKthLargest(nums, k) {
+  if (nums.length === 1) {
+    return nums[nums.length - 1];
+  }
+  const sortedNums = quickSort(nums, 0, nums.length - 1);
+  return sortedNums[sortedNums.length - k];
+}
+
+function quickSort(nums, leftIndex, rightIndex) {
+  if (leftIndex >= rightIndex) {
+    return;
+  }
+
+  const mid = Math.floor((leftIndex + rightIndex) / 2);
+  const pivot = nums[mid];
+
+  const partitionIndex = divide(nums, leftIndex, rightIndex, pivot);
+
+  quickSort(nums, leftIndex, partitionIndex - 1);
+  quickSort(nums, partitionIndex, rightIndex);
+
+  return nums;
+}
+
+function divide(nums, left, right, pivot) {
+  while (left <= right) {
+    while (nums[left] < pivot) {
+      left++;
+    }
+
+    while (nums[right] > pivot) {
+      right--;
+    }
+
+    if (left <= right) {
+      let temp = nums[left];
+      nums[left] = nums[right];
+      nums[right] = temp;
+
+      left++;
+      right--;
+    }
+  }
+
+  return left;
+}
+
+console.log(findKthLargest([1], 1));
+console.log(findKthLargest([3, 2, 1, 5, 6, 4], 2)); // 5
+console.log(findKthLargest([3, 2, 3, 1, 2, 4, 5, 5, 6], 4)); // 4

--- a/src/weekly31/den/leetcode/48_Rotate_Image.ts
+++ b/src/weekly31/den/leetcode/48_Rotate_Image.ts
@@ -2,6 +2,7 @@
  * 문제출처: https://leetcode.com/problems/rotate-image/
  * 시작시간: 13:45
  * 종료시간: 14:30
+ * 결과: 성공
  */
 
 function rotate(matrix: number[][]): void {

--- a/src/weekly31/den/leetcode/rotate-image.ts
+++ b/src/weekly31/den/leetcode/rotate-image.ts
@@ -1,0 +1,29 @@
+/**
+ * 문제출처: https://leetcode.com/problems/rotate-image/
+ * 시작시간: 13:45
+ * 종료시간: 14:30
+ */
+
+function rotate(matrix: number[][]): void {
+  const duplicateArray: number[][] = [];
+
+  for (let i = 0; i < matrix.length; i++) {
+    const innerArray: number[] = [];
+    for (let j = 0; j < matrix[i].length; j++) {
+      innerArray.push(matrix[i][j]);
+    }
+    duplicateArray.push(innerArray);
+  }
+
+  for (let i = 0; i < matrix.length; i++) {
+    for (let j = 0; j < matrix.length; j++) {
+      matrix[i][j] = duplicateArray[matrix.length - 1 - j][i];
+    }
+  }
+}
+
+// Input: matrix = [[1,2,3],[4,5,6],[7,8,9]]
+// Output: [[7,4,1],[8,5,2],[9,6,3]]
+
+// Input: matrix = [[5,1,9,11],[2,4,8,10],[13,3,6,7],[15,14,12,16]]
+// Output: [[15,13,2,5],[14,3,4,1],[12,6,8,9],[16,7,10,11]]


### PR DESCRIPTION
### 48. Rotate Image
- 출처 : [leetcode - medium](https://leetcode.com/problems/rotate-image/)

### 입력 및 출력 설명

> Example 1

```js
Input: matrix = [[1,2,3],[4,5,6],[7,8,9]]
Output: [[7,4,1],[8,5,2],[9,6,3]]
```

> Example 2

```js
Input: matrix = [[5,1,9,11],[2,4,8,10],[13,3,6,7],[15,14,12,16]]
Output: [[15,13,2,5],[14,3,4,1],[12,6,8,9],[16,7,10,11]]
```

### 문제 풀이 과정
그림으로 표현하면 n * n 크기의 matrix 형태인 2차원 배열이 입력으로 주어지고, 이 2차원 배열을 시계방향으로 90도 돌린다고 했을 때의 2차원 배열을 구하는 문제 입니다.

90도를 돌릴 때, 2차원 배열의 모든 요소는 같은 방향으로 돌기 때문에 어떤 요소가 어떤 위치로 어떻게 이동하는지 규칙을 찾을 수 있습니다.

예를 들어,
matrix[0][0]의 값은 matrix[3][0]의 값과 위치가 바뀝니다.
matrix[0][1]의 값은 matrix[2][0]의 값과 위치가 바뀝니다.
matrix[0][2]의 값은 matrix[1][0]의 값과 위치가 바뀝니다.
...

이렇게 쭉 바뀌는 패턴을 유추해보면, 2차원 배열의 x좌표가 i, y좌표가 j라고 했을 때 matrix[i][j]의 값은 matrix[matrix.length - 1 - j][i]의 값과 위치가 바뀐다는 것을 알 수 있습니다.

이를 2중 for문을 이용해서 matrix를 순회하면서, 이 규칙을 대입하며 2차원 배열의 각 요소의 위치를 바꾸면 문제에서 요구하는 2차원 배열을 구할 수 있습니다.

단, 위 규칙으로 배열을 순회하며 각 요소의 위치를 바꿨을 때, 이미 바꿘 요소들의 경우 한번이 아닌 두 번 이상 위치가 바뀌어서 로직이 꼬일 수 있기 때문에 이를 방지하기 위한 추가 로직이 필요합니다. 저 같은 경우에, 이를 방지하기 위해서 미리 복제본을 만들고 이를 활용했습니다.

### 215. Kth Largest Element In An Array
- 출처 : [leetcode - medium](https://leetcode.com/problems/kth-largest-element-in-an-array/)

### 입력 및 출력 설명

> Example 1

```js
Input: [3, 2, 1, 5, 6, 4], 2
Output: 5
```

> Example 2

```js
Input: [3, 2, 3, 1, 2, 4, 5, 5, 6], 4
Output: 4
```

### 문제 풀이 과정
주어진 배열에서 k번째 큰 수를 구하는 문제입니다. 단, sort 사용을 지양해달라는 조건이 있습니다.

k번 째 큰 수를 구하기 위해서 우선 주어진 배열을 2중 for문으로 순회하며 내림차순 정렬을 했습니다. 그리고 내림차순 정렬을 한 배열에서 k번째로 큰 수를 구하는 로직을 구현 했습니다.

이 로직을 제출했지만, test case 40개 중 37개만 통과하고, 결국 완전한 통과를 못 했습니다.

이유를 분석해보니, 이 문제에서 주어지는 배열의 조건은 1부터 무려 10의 5승으로, 시간 복잡도가 O(N^2)인 저의 로직으로는 풀 수가 없는 문제였습니다.

그래서 써치한 끝에, 퀵 선택 정렬 알고리즘을 학습하고 다시 로직을 구현했습니다.

퀵 정렬은 Divide and Conquer 전략을 사용하는 알고리즘입니다.
정렬하는데 가장 간단한 배열은 요소가 없거나 하나만 있는 배열이므로 모든 배열이 기본 배열이 될 때까지 큰 배열을 나눕니다.
단, 그냥 나누는 것이 아니고 퀵 정렬에서는 우선 요소 하나를 기준 원소인 pivot으로 설정합니다.
그리고 기준 원소의 왼쪽에는 기준 원소보다 작은 값의 배열을 놓고 오른쪽에는 기준 원소보다 큰 값을 놓습니다.
pivot을 기준으로 나눠진 각 배열에서 다시 pivot을 설정하고 위 규칙을 반복합니다.
계속 반복하면 원소가 하나인 배열만 남고, 이 배열들을 합치면 정렬이 완료 됩니다.

퀵 정렬을 사용하면, 최악의 경우 O(N^2)의 복잡도가 발생하지만, 최선의 경우 복잡도는 O(nlogn)입니다. 
최악의 경우일 때, 퀵 정렬도 위 문제를 풀 수 없을 가능성이 있지만, O(N^2) 복잡도인 기존 로직보다 더 나은 복잡도일 가능성이 높아서 퀵 정렬을 이용한 로직을 구현해 봤습니다.

퀵 정렬을 구현하는 방법도 몇 가지가 있는데, 그 중에서 공간 복잡도 등의 측면에서 더 나은 In-Place 방식으로 구현 했습니다.

1. quickSort 함수 구현

- pivot을 배열의 중앙 값으로 지정.
- pivot을 기준으로 양쪽 배열이 정렬이 완료되면, 다시 quickSort 재귀 호출
- 재귀 호출이 모두 완료되면, 정렬이 완료된 배열을 반환

2. divide 함수 구현

- 배열, leftIndex(왼쪽 끝 index 값), rightIndex(오른쪽 끝 index 값), pivot 을 매개변수로 받음
- 왼쪽 끝 index 값이 오른쪽 끝 index값 보다 작거나 클 태까지 반복문 호출
 - 왼쪽 배열의 요소가 pivot 보다 작으면, 정렬할 필요가 없으므로 pass 되게끔 left 값 1씩 증가시킨다.
 - 오른쪽 배열의 요소가 pivot 보다 크면 정렬할 필요가 없으므로 pass 되게끔 right 값 1씩 감소시킨다.
 - 왼쪽과 오른쪽 요소가 정렬 조건에 맞을 때, 왼쪽 요소와 오른쪽 요소의 위치를 바꾼다.
- 왼쪽 과 오른쪽의 index 값이 서로 교차하면 반복문이 종료되면서, pivot index인 left 값을 반환한다.

3. 위 두 함수를 이용해서 정렬된 배열을 구하고, 이 배열에서 k 번째로 큰 수를 구한다.



