### PR TITLE
Den / 36주차 / 1.5문제 

### DIFF
--- a/src/weekly36/den/programmers/더 맵게.js
+++ b/src/weekly36/den/programmers/더 맵게.js
@@ -1,0 +1,22 @@
+function solution(scoville, K) {
+  let mixedCount = 0;
+
+  const sortedScoville = scoville.sort((a, b) => b - a);
+
+  while (sortedScoville.length >= 2) {
+    const [least, secondLeast] = [sortedScoville.pop(), sortedScoville.pop()];
+
+    const mixedScov = calcMixedCov(least, secondLeast);
+
+    sortedScoville.push(mixedScov);
+    sortedScoville.sort((a, b) => b - a);
+
+    mixedCount++;
+  }
+
+  return sortedScoville.at(-1) >= K ? mixedCount : -1;
+}
+
+const calcMixedCov = (least, secondLeast) => {
+  return least + secondLeast * 2;
+};

--- a/src/weekly36/den/programmers/폰켓몬.js
+++ b/src/weekly36/den/programmers/폰켓몬.js
@@ -1,0 +1,5 @@
+function solution(nums) {
+  const maximum = nums.length / 2;
+
+  return new Set([...nums]).size > maximum ? maximum : new Set([...nums]).size;
+}


### PR DESCRIPTION
### 폰켓몬
- 출처 : [programmers - lv.1][(url](https://school.programmers.co.kr/learn/courses/30/lessons/1845))

### 문제 풀이 과정
입력 Nums의 길이의 반보다 작은 수의 폰켓몬을 고르는 문제다.
우선, Set으로 중복을 제거한 Nums 배열의 길이를 계산해서, maximum과의 길이를 비교해서 값을 반환했다.

---

### 더 맵게

### Example

scoville | K | return
-- | -- | --
[1, 2, 3, 9, 10, 12] | 7 | 2

### 문제풀이
결과적으로 효율성 테스트를 통과하지 못 했습니다.
우선 매개변수로 주어진 scoville을 오름차순으로 sort 했습니다.
그리고 while문을 돌면서 scoville의 제일 작은 수와, 그 다음 작은 수를 pop해서 mizedScov 값을 구했습니다.
이를 모든 지수를 섞어서 모든 지수를 K보다 크게 만들기를 시도 했는데, 예시 테스트는 통과했지만 결과적으로 효율성 테스트는 통과 못 했습니다.